### PR TITLE
Fix flake8 configuration

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,4 @@
 [flake8]
 exclude = alembic/versions/*
-ignore = W291,W292,W293,E302,E501,F401 
+extend-select = B
+max-line-length = 120


### PR DESCRIPTION
## Summary
- update `.flake8` to enable bugbear rules and set max line length to 120

## Testing
- `black .`
- `flake8 . --max-line-length 120` *(fails: F401 imported but unused, etc.)*
- `mypy app/ services/ logic/ -p app --strict` *(fails: may only specify one of module/package, files, or command)*
- `pytest -q -x` *(fails: ModuleNotFoundError: No module named 'flask')*
- `alembic upgrade head` *(fails: ImportError: cannot import name 'config')*

------
https://chatgpt.com/codex/tasks/task_e_6842893af084832c8e3d5751108eafd8