### PR TITLE
Refactor: apply Core → Channels → API layout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables
+
+GOOGLE_SVC_KEY=/path/to/service-account.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,3 +80,8 @@ Layer: <core|channels|api>
 ---
 
 \*Last updated: \<YYYY‑MM‑DD>
+
+## Google Workspace
+App owns one Drive folder per organisation (ensure_workspace).
+All sheets created via core.services.drive/sheets.
+Sheets remain read-only until TWO_WAY_SYNC_ENABLED is True.

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,6 +1,10 @@
-"""API package."""
+"""API package.
+
+Layer: api
+"""
 
 from app.api.catalog import bp as catalog_bp
 from app.api.export import bp as export_bp
+from app.api.auth import bp as auth_bp
 
-__all__ = ['catalog_bp', 'export_bp'] 
+__all__ = ['catalog_bp', 'export_bp', 'auth_bp']

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -1,9 +1,9 @@
-"""Authentication API endpoints."""
+"""Authentication API endpoints.
 
-from flask import Blueprint, request, jsonify
-from sqlalchemy.orm import Session
+Layer: api
+"""
+from flask import Blueprint, request, jsonify, current_app
 from app.core.auth.service import AuthService
-from app.core.auth.models import User
 from app import db
 
 bp = Blueprint('auth', __name__, url_prefix='/api/auth')

--- a/app/api/catalog.py
+++ b/app/api/catalog.py
@@ -1,24 +1,27 @@
-"""Catalog API endpoints."""
+"""Catalog API endpoints.
+
+Layer: api
+"""
 
 from flask import Blueprint, request, jsonify
 from app.core.models.product import MasterProduct, InventoryRecord
 from app.core.services.sheets import SheetsService
-from sqlalchemy.orm import Session
+from app import db
 
 bp = Blueprint('catalog', __name__, url_prefix='/api/catalog')
 
 @bp.route('/products', methods=['GET'])
 def get_products():
     """Get all products."""
-    db = Session()
-    products = db.query(MasterProduct).all()
+    session = db.session
+    products = session.query(MasterProduct).all()
     return jsonify([product.to_dict() for product in products])
 
 @bp.route('/products/<int:product_id>', methods=['GET'])
 def get_product(product_id: int):
     """Get a single product."""
-    db = Session()
-    product = db.query(MasterProduct).get(product_id)
+    session = db.session
+    product = session.query(MasterProduct).get(product_id)
     if not product:
         return jsonify({'error': 'Product not found'}), 404
     return jsonify(product.to_dict())
@@ -27,43 +30,43 @@ def get_product(product_id: int):
 def create_product():
     """Create a new product."""
     data = request.get_json()
-    db = Session()
+    session = db.session
     product = MasterProduct.from_dict(data)
-    db.add(product)
-    db.commit()
-    db.refresh(product)
+    session.add(product)
+    session.commit()
+    session.refresh(product)
     return jsonify(product.to_dict()), 201
 
 @bp.route('/products/<int:product_id>', methods=['PUT'])
 def update_product(product_id: int):
     """Update a product."""
     data = request.get_json()
-    db = Session()
-    product = db.query(MasterProduct).get(product_id)
+    session = db.session
+    product = session.query(MasterProduct).get(product_id)
     if not product:
         return jsonify({'error': 'Product not found'}), 404
     
     for key, value in data.items():
         setattr(product, key, value)
     
-    db.commit()
-    db.refresh(product)
+    session.commit()
+    session.refresh(product)
     return jsonify(product.to_dict())
 
 @bp.route('/inventory', methods=['GET'])
 def get_inventory():
     """Get inventory records."""
-    db = Session()
-    records = db.query(InventoryRecord).all()
+    session = db.session
+    records = session.query(InventoryRecord).all()
     return jsonify([record.to_dict() for record in records])
 
 @bp.route('/inventory', methods=['POST'])
 def create_inventory_record():
     """Create a new inventory record."""
     data = request.get_json()
-    db = Session()
+    session = db.session
     record = InventoryRecord.from_dict(data)
-    db.add(record)
-    db.commit()
-    db.refresh(record)
+    session.add(record)
+    session.commit()
+    session.refresh(record)
     return jsonify(record.to_dict()), 201 

--- a/app/api/export.py
+++ b/app/api/export.py
@@ -1,10 +1,13 @@
-"""Export API endpoints."""
+"""Export API endpoints.
+
+Layer: api
+"""
 
 from flask import Blueprint, request, jsonify
 from app.core.services.sheets import SheetsService
 from app.core.services.drive import DriveService
 from app.core.models.product import MasterProduct, InventoryRecord
-from sqlalchemy.orm import Session
+from app import db
 
 bp = Blueprint('export', __name__, url_prefix='/api/export')
 
@@ -18,8 +21,8 @@ def export_products_to_sheets():
     if not spreadsheet_id or not range_name:
         return jsonify({'error': 'spreadsheet_id and range_name are required'}), 400
     
-    db = Session()
-    products = db.query(MasterProduct).all()
+    session = db.session
+    products = session.query(MasterProduct).all()
     data = [product.to_dict() for product in products]
     
     sheets_service = SheetsService(None)  # TODO: Get credentials from config
@@ -37,8 +40,8 @@ def export_inventory_to_sheets():
     if not spreadsheet_id or not range_name:
         return jsonify({'error': 'spreadsheet_id and range_name are required'}), 400
     
-    db = Session()
-    records = db.query(InventoryRecord).all()
+    session = db.session
+    records = session.query(InventoryRecord).all()
     data = [record.to_dict() for record in records]
     
     sheets_service = SheetsService(None)  # TODO: Get credentials from config
@@ -56,8 +59,8 @@ def export_products_to_drive():
     if not folder_id:
         return jsonify({'error': 'folder_id is required'}), 400
     
-    db = Session()
-    products = db.query(MasterProduct).all()
+    session = db.session
+    products = session.query(MasterProduct).all()
     data = [product.to_dict() for product in products]
     
     # TODO: Convert data to CSV

--- a/app/channels/base.py
+++ b/app/channels/base.py
@@ -1,4 +1,7 @@
-"""Base channel interface."""
+"""Base channel interface.
+
+Layer: channels
+"""
 
 from abc import ABC, abstractmethod
 from datetime import datetime

--- a/app/channels/template_mixin.py
+++ b/app/channels/template_mixin.py
@@ -1,0 +1,18 @@
+"""Optional mixin for channels providing spreadsheet templates.
+
+Layer: channels
+"""
+
+from abc import ABC, abstractmethod
+from typing import Dict
+
+__all__ = ["SpreadsheetTemplateProvider"]
+
+
+class SpreadsheetTemplateProvider(ABC):
+    """Provide paths to channel-specific spreadsheet templates."""
+
+    @abstractmethod
+    def list_templates(self) -> Dict[str, str]:
+        """Return mapping of template keys to relative file paths."""
+        raise NotImplementedError

--- a/app/channels/woot/logic.py
+++ b/app/channels/woot/logic.py
@@ -1,0 +1,60 @@
+"""PORF ingestion helpers.
+
+Layer: channels
+"""
+
+from __future__ import annotations
+
+import csv
+import logging
+from io import BytesIO
+from typing import BinaryIO, Dict, List
+
+from app import db
+from app.core.services.drive import DriveService
+from app.core.services.sheets import SheetsService
+from .models import WootPorf, WootPorfLine, WootPorfStatus
+
+logger = logging.getLogger(__name__)
+
+TEMPLATE_ID = "TEMPLATE_ID"
+
+
+def ingest_porf(
+    upload_file: BinaryIO, drive: DriveService, sheets: SheetsService
+) -> Dict[str, str]:
+    """Parse PORF spreadsheet, store rows and create a Sheets copy."""
+    logger.debug("ingest_porf start")
+
+    reader = csv.DictReader(BytesIO(upload_file.read()).read().decode().splitlines())
+    porf = WootPorf(status=WootPorfStatus.DRAFT)
+    db.session.add(porf)
+    canonical_rows: List[List[str]] = []
+    for row in reader:
+        line = WootPorfLine(
+            porf=porf,
+            product_id=row.get("product_id", ""),
+            product_name=row.get("product_name", ""),
+            quantity=int(row.get("quantity", 0)),
+            unit_price=float(row.get("unit_price", 0)),
+            total_price=float(row.get("quantity", 0)) * float(row.get("unit_price", 0)),
+        )
+        db.session.add(line)
+        canonical_rows.append(
+            [
+                line.product_id,
+                line.product_name,
+                str(line.quantity),
+                str(line.unit_price),
+                str(line.total_price),
+            ]
+        )
+    db.session.commit()
+
+    workspace = drive.ensure_workspace("default")
+    dst_folder = drive.ensure_subfolder(workspace, "woot/porfs")
+    sheet_id, url = sheets.copy_template(TEMPLATE_ID, f"PORF-{porf.id}", dst_folder)
+    sheets.append_rows(sheet_id, canonical_rows)
+
+    logger.info("ingest_porf success")
+    return {"porf_id": str(porf.id), "sheet_url": url}

--- a/app/channels/woot/routes.py
+++ b/app/channels/woot/routes.py
@@ -1,4 +1,7 @@
-"""Woot channel routes."""
+"""Woot channel routes.
+
+Layer: channels
+"""
 
 import os
 from datetime import datetime
@@ -6,7 +9,6 @@ from typing import Dict, List, Optional, Any
 from flask import Blueprint, request, jsonify, current_app
 from flask_login import login_required, current_user
 from google.oauth2.credentials import Credentials
-from sqlalchemy.orm import Session
 
 from app import db
 from app.channels.woot.models import WootPorf, WootPo, WootPorfStatus, WootPoStatus, PORF, PO
@@ -30,9 +32,9 @@ def get_woot_service() -> WootService:
 
 def get_service() -> WootOrderService:
     """Get the Woot order service instance."""
-    db = Session()
+    session = db.session
     sheets_service = SheetsService(None)  # TODO: Get credentials from config
-    return WootOrderService(db, sheets_service)
+    return WootOrderService(session, sheets_service)
 
 @bp.route('/porfs', methods=['POST'])
 @login_required

--- a/app/core/logic/__init__.py
+++ b/app/core/logic/__init__.py
@@ -2,5 +2,6 @@
 
 from app.core.logic.catalog import CatalogManager
 from app.core.logic.orders import OrderManager
+from app.core.logic.utils import add_months
 
-__all__ = ['CatalogManager', 'OrderManager'] 
+__all__ = ['CatalogManager', 'OrderManager', 'add_months']

--- a/app/core/logic/utils.py
+++ b/app/core/logic/utils.py
@@ -1,0 +1,14 @@
+"""Utility helpers for core logic.
+
+Layer: core
+"""
+
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
+
+__all__ = ["add_months"]
+
+
+def add_months(dt: datetime, months: int) -> datetime:
+    """Return ``dt`` shifted by ``months`` months."""
+    return dt + relativedelta(months=months)

--- a/app/core/models/product.py
+++ b/app/core/models/product.py
@@ -1,30 +1,38 @@
 """Core product models for the application."""
 
-from sqlalchemy import Column, String, JSON
+from sqlalchemy import Column, String, JSON, Integer, ForeignKey
 from sqlalchemy.orm import relationship
 from app.core.models.base import BaseModel
 
+
 class MasterProduct(BaseModel):
     """Master product model."""
-    __tablename__ = 'master_products'
-    
+
+    __tablename__ = "master_products"
+
     sku = Column(String(50), unique=True, nullable=False)
     title = Column(String(200), nullable=False)
     description = Column(String(1000))
     extra_data = Column(JSON)
-    
+
     # Relationships
-    inventory_records = relationship('InventoryRecord', back_populates='product', cascade='all, delete-orphan')
+    inventory_records = relationship(
+        "InventoryRecord", back_populates="product", cascade="all, delete-orphan"
+    )
+
 
 class InventoryRecord(BaseModel):
     """Inventory record model."""
-    __tablename__ = 'inventory_records'
-    
-    product_id = Column(Integer, ForeignKey('master_products.id'), nullable=False)
-    quantity_delta = Column(Integer, nullable=False)  # Positive for additions, negative for removals
+
+    __tablename__ = "inventory_records"
+
+    product_id = Column(Integer, ForeignKey("master_products.id"), nullable=False)
+    quantity_delta = Column(
+        Integer, nullable=False
+    )  # Positive for additions, negative for removals
     source = Column(String(50), nullable=False)  # e.g., 'manual', 'woot', 'amazon'
     notes = Column(String(500))
     extra_data = Column(JSON)
-    
+
     # Relationships
-    product = relationship('MasterProduct', back_populates='inventory_records') 
+    product = relationship("MasterProduct", back_populates="inventory_records")

--- a/app/core/services/drive.py
+++ b/app/core/services/drive.py
@@ -5,32 +5,31 @@ from googleapiclient.errors import HttpError
 from googleapiclient.http import MediaFileUpload, MediaIoBaseDownload
 import io
 
+
 class DriveService:
     """Core service for interacting with Google Drive."""
-    
+
     def __init__(self, credentials: Credentials):
-        self.service = build('drive', 'v3', credentials=credentials)
+        self.service = build("drive", "v3", credentials=credentials)
         self.files = self.service.files()
-    
+
     def list_files(self, query: Optional[str] = None) -> List[Dict[str, Any]]:
         """List files in Google Drive, optionally filtered by query."""
         try:
             results = self.files.list(
-                q=query,
-                pageSize=100,
-                fields="nextPageToken, files(id, name, mimeType)"
+                q=query, pageSize=100, fields="nextPageToken, files(id, name, mimeType)"
             ).execute()
-            return results.get('files', [])
+            return results.get("files", [])
         except HttpError as error:
             raise Exception(f"Error listing files: {error}")
-    
+
     def get_file(self, file_id: str) -> Dict[str, Any]:
         """Get metadata for a specific file."""
         try:
             return self.files.get(fileId=file_id, fields="id, name, mimeType").execute()
         except HttpError as error:
             raise Exception(f"Error getting file: {error}")
-    
+
     def download_file(self, file_id: str) -> bytes:
         """Download a file's contents."""
         try:
@@ -43,42 +42,70 @@ class DriveService:
             return file.getvalue()
         except HttpError as error:
             raise Exception(f"Error downloading file: {error}")
-    
-    def upload_file(self, file_path: str, mime_type: str, name: Optional[str] = None) -> Dict[str, Any]:
+
+    def upload_file(
+        self, file_path: str, mime_type: str, name: Optional[str] = None
+    ) -> Dict[str, Any]:
         """Upload a file to Google Drive."""
         try:
-            file_metadata = {'name': name}
+            file_metadata = {"name": name}
             media = MediaFileUpload(file_path, mimetype=mime_type, resumable=True)
             file = self.files.create(
-                body=file_metadata,
-                media_body=media,
-                fields='id'
+                body=file_metadata, media_body=media, fields="id"
             ).execute()
             return file
         except HttpError as error:
             raise Exception(f"Error uploading file: {error}")
-    
+
     def delete_file(self, file_id: str) -> None:
         """Delete a file from Google Drive."""
         try:
             self.files.delete(fileId=file_id).execute()
         except HttpError as error:
             raise Exception(f"Error deleting file: {error}")
-    
-    def create_folder(self, name: str, parent_id: Optional[str] = None) -> Dict[str, Any]:
+
+    def create_folder(
+        self, name: str, parent_id: Optional[str] = None
+    ) -> Dict[str, Any]:
         """Create a new folder in Google Drive."""
         try:
             file_metadata = {
-                'name': name,
-                'mimeType': 'application/vnd.google-apps.folder'
+                "name": name,
+                "mimeType": "application/vnd.google-apps.folder",
             }
             if parent_id:
-                file_metadata['parents'] = [parent_id]
-            
-            file = self.files.create(
-                body=file_metadata,
-                fields='id'
-            ).execute()
+                file_metadata["parents"] = [parent_id]
+
+            file = self.files.create(body=file_metadata, fields="id").execute()
             return file
         except HttpError as error:
-            raise Exception(f"Error creating folder: {error}") 
+            raise Exception(f"Error creating folder: {error}")
+
+    # ------------------------------------------------------------------
+    # Convenience helpers used by channel logic
+    # ------------------------------------------------------------------
+    def ensure_workspace(self, org_id: str) -> str:
+        """Return the workspace folder for an organisation."""
+        query = (
+            f"name = 'Your-App-Workspace-{org_id}' and "
+            "mimeType = 'application/vnd.google-apps.folder' and trashed = false"
+        )
+        existing = self.list_files(query)
+        if existing:
+            return existing[0]["id"]
+
+        folder = self.create_folder(f"Your-App-Workspace-{org_id}")
+        return folder["id"]
+
+    def ensure_subfolder(self, parent_id: str, name: str) -> str:
+        """Return sub-folder ``name`` under ``parent_id``."""
+        query = (
+            f"name = '{name}' and '{parent_id}' in parents and "
+            "mimeType = 'application/vnd.google-apps.folder' and trashed = false"
+        )
+        existing = self.list_files(query)
+        if existing:
+            return existing[0]["id"]
+
+        folder = self.create_folder(name, parent_id)
+        return folder["id"]

--- a/app/core/services/sheets.py
+++ b/app/core/services/sheets.py
@@ -3,64 +3,105 @@ from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 
+TWO_WAY_SYNC_ENABLED = False
+
+
 class SheetsService:
     """Core service for interacting with Google Sheets."""
-    
+
     def __init__(self, credentials: Credentials):
-        self.service = build('sheets', 'v4', credentials=credentials)
+        self.service = build("sheets", "v4", credentials=credentials)
         self.spreadsheets = self.service.spreadsheets()
-    
+
     def get_sheet_data(self, spreadsheet_id: str, range_name: str) -> List[List[Any]]:
         """Get data from a specific range in a spreadsheet."""
         try:
-            result = self.spreadsheets.values().get(
-                spreadsheetId=spreadsheet_id,
-                range=range_name
-            ).execute()
-            return result.get('values', [])
+            result = (
+                self.spreadsheets.values()
+                .get(spreadsheetId=spreadsheet_id, range=range_name)
+                .execute()
+            )
+            return result.get("values", [])
         except HttpError as error:
             raise Exception(f"Error fetching sheet data: {error}")
-    
-    def update_sheet_data(self, spreadsheet_id: str, range_name: str, values: List[List[Any]]) -> Dict[str, Any]:
+
+    def update_sheet_data(
+        self, spreadsheet_id: str, range_name: str, values: List[List[Any]]
+    ) -> Dict[str, Any]:
         """Update data in a specific range of a spreadsheet."""
         try:
-            body = {
-                'values': values
-            }
-            result = self.spreadsheets.values().update(
-                spreadsheetId=spreadsheet_id,
-                range=range_name,
-                valueInputOption='RAW',
-                body=body
-            ).execute()
+            body = {"values": values}
+            result = (
+                self.spreadsheets.values()
+                .update(
+                    spreadsheetId=spreadsheet_id,
+                    range=range_name,
+                    valueInputOption="RAW",
+                    body=body,
+                )
+                .execute()
+            )
             return result
         except HttpError as error:
             raise Exception(f"Error updating sheet data: {error}")
-    
-    def append_sheet_data(self, spreadsheet_id: str, range_name: str, values: List[List[Any]]) -> Dict[str, Any]:
+
+    def append_sheet_data(
+        self, spreadsheet_id: str, range_name: str, values: List[List[Any]]
+    ) -> Dict[str, Any]:
         """Append data to a specific range in a spreadsheet."""
         try:
-            body = {
-                'values': values
-            }
-            result = self.spreadsheets.values().append(
-                spreadsheetId=spreadsheet_id,
-                range=range_name,
-                valueInputOption='RAW',
-                insertDataOption='INSERT_ROWS',
-                body=body
-            ).execute()
+            body = {"values": values}
+            result = (
+                self.spreadsheets.values()
+                .append(
+                    spreadsheetId=spreadsheet_id,
+                    range=range_name,
+                    valueInputOption="RAW",
+                    insertDataOption="INSERT_ROWS",
+                    body=body,
+                )
+                .execute()
+            )
             return result
         except HttpError as error:
             raise Exception(f"Error appending sheet data: {error}")
-    
+
     def clear_sheet_data(self, spreadsheet_id: str, range_name: str) -> Dict[str, Any]:
         """Clear data from a specific range in a spreadsheet."""
         try:
-            result = self.spreadsheets.values().clear(
-                spreadsheetId=spreadsheet_id,
-                range=range_name
-            ).execute()
+            result = (
+                self.spreadsheets.values()
+                .clear(spreadsheetId=spreadsheet_id, range=range_name)
+                .execute()
+            )
             return result
         except HttpError as error:
-            raise Exception(f"Error clearing sheet data: {error}") 
+            raise Exception(f"Error clearing sheet data: {error}")
+
+    # ------------------------------------------------------------------
+    # Convenience helpers used by channel logic
+    # ------------------------------------------------------------------
+    def open_sheet(self, sheet_id: str):
+        """Return the spreadsheet metadata."""
+        return self.spreadsheets.get(spreadsheetId=sheet_id).execute()
+
+    def copy_template(
+        self, src_id: str, dst_title: str, folder_id: str
+    ) -> tuple[str, str]:
+        """Copy ``src_id`` to ``dst_title`` inside ``folder_id``."""
+        body = {"name": dst_title, "parents": [folder_id]}
+        copy = self.service.files().copy(fileId=src_id, body=body).execute()
+        sheet_id = copy["id"]
+        url = f"https://docs.google.com/spreadsheets/d/{sheet_id}"
+        return sheet_id, url
+
+    def append_rows(self, sheet_id: str, rows: List[List[str]]):
+        """Append ``rows`` to the first worksheet."""
+        body = {"values": rows}
+        self.spreadsheets.values().append(
+            spreadsheetId=sheet_id,
+            range="A1",
+            valueInputOption="USER_ENTERED",
+            insertDataOption="INSERT_ROWS",
+            body=body,
+        ).execute()

--- a/app/core/services/spreadsheet.py
+++ b/app/core/services/spreadsheet.py
@@ -1,0 +1,38 @@
+"""Spreadsheet builder utilities.
+
+Layer: core
+"""
+
+from pathlib import Path
+import csv
+from typing import List, Dict
+from openpyxl import load_workbook
+
+__all__ = ["SpreadsheetBuilder"]
+
+
+class SpreadsheetBuilder:
+    """Build spreadsheets from row dictionaries using templates."""
+
+    def __init__(self, template_path: Path):
+        self.template_path = template_path
+
+    def write_excel(self, rows: List[Dict[str, object]], output_path: Path) -> Path:
+        wb = load_workbook(self.template_path)
+        ws = wb.active
+        headers = [cell.value for cell in next(ws.iter_rows(max_row=1))]
+        for row_idx, row in enumerate(rows, start=2):
+            for col_idx, header in enumerate(headers, start=1):
+                ws.cell(row=row_idx, column=col_idx, value=row.get(header))
+        wb.save(output_path)
+        return output_path
+
+    def write_csv(self, rows: List[Dict[str, object]], output_path: Path) -> Path:
+        if not rows:
+            raise ValueError("No data to write")
+        headers = rows[0].keys()
+        with open(output_path, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=headers)
+            writer.writeheader()
+            writer.writerows(rows)
+        return output_path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,12 +44,7 @@ def db_session(engine):
 # Flask app + client that use the same in-memory DB
 # ------------------------------------------------------------------
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-spec = importlib.util.spec_from_file_location(
-    "app", str(Path(__file__).resolve().parent.parent / "app.py")
-)
-app_module = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(app_module)
-create_app = app_module.create_app
+from app.main import create_app
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Context
Cursor produced an initial migration to the three-layer model described in AGENTS.md.

## What’s in this PR
* New `core/`, `channels/`, `api/` folders
* Woot tables moved to `channels/woot/models.py`
* Basic BaseChannelOrderService interface
* Salvaged helpers from legacy logic
* Cleaned up API session handling

## What still needs Codex review
* Salvage reusable helpers from legacy `app/services` + `app/utils`
* Remove dead routes that now live under channel packages
* Ensure import rule (api→channels→core) has no violations

------
https://chatgpt.com/codex/tasks/task_e_68460bcc455c832c80fa2df227c39156