### PR TITLE
Remove placeholder tests

### DIFF
--- a/app/core/oauth.py
+++ b/app/core/oauth.py
@@ -6,11 +6,10 @@ Layer: core
 import logging
 from flask import current_app, redirect, url_for
 from flask_dance.contrib.google import make_google_blueprint, google
-from flask_dance.consumer import oauth_authorized, oauth_error
+from flask_dance.consumer import OAuth2ConsumerBlueprint, oauth_authorized, oauth_error
 from flask_dance.consumer.storage.sqla import SQLAlchemyStorage
 from sqlalchemy.orm.exc import NoResultFound
 from flask_login import current_user
-from flask_dance.contrib.google import Blueprint
 
 from app.core.models.user import User
 from app import db
@@ -22,7 +21,7 @@ __all__ = ["google", "google_bp", "create_google_bp", "init_oauth"]
 # Stub for google_bp to satisfy import in tests/conftest.py
 google_bp = None
 
-def create_google_bp() -> Blueprint:
+def create_google_bp() -> OAuth2ConsumerBlueprint:
     """Create and configure the Google OAuth blueprint.
     
     Returns:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -94,12 +94,3 @@ def get_mock_responses():
         'sheets': TEST_CONFIG['MOCK_SHEETS_RESPONSES'],
         'oauth': TEST_CONFIG['MOCK_OAUTH_RESPONSES'],
     }
-
-def test_config_setup() -> None:
-    pass
-
-def test_config_teardown() -> None:
-    pass
-
-def test_config_reload() -> None:
-    pass 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -63,12 +63,3 @@ def test_ensure_workspace(monkeypatch) -> None:
         ("porfs", "woot_id"),
         ("pos", "woot_id"),
     ]
-
-def test_workspace_setup() -> None:
-    pass
-
-def test_workspace_teardown() -> None:
-    pass
-
-def test_workspace_reload() -> None:
-    pass 


### PR DESCRIPTION
## Summary
- remove unused placeholder tests for workspace/config
- update `create_google_bp` annotation to avoid missing import

## Testing
- `pytest -q` *(fails: FileMetadata not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684772e7c4c8832cb8a403051d4f7601