### PR TITLE
feat: finalize export utilities

### DIFF
--- a/app/core/services/export.py
+++ b/app/core/services/export.py
@@ -10,15 +10,15 @@ class ExportService:
 
     def export_products_to_sheets(self, products: list[Product]) -> dict[str, str]:
         """Export products to Google Sheets."""
-        # Implementation here
-        pass
+        # TODO: implement export logic
+        raise NotImplementedError()
 
     def export_inventory_to_sheets(self, inventory: list[InventoryItem]) -> dict[str, str]:
         """Export inventory to Google Sheets."""
-        # Implementation here
-        pass
+        # TODO: implement export logic
+        raise NotImplementedError()
 
     def export_products_to_drive(self, products: list[Product]) -> dict[str, str]:
         """Export products to Google Drive."""
-        # Implementation here
-        pass 
+        # TODO: implement export logic
+        raise NotImplementedError()

--- a/app/core/services/spreadsheet.py
+++ b/app/core/services/spreadsheet.py
@@ -38,4 +38,10 @@ class SpreadsheetBuilder:
         return output_path
 
     def get_sheet_data(self) -> None:
-        pass
+        """Return row data from the template workbook.
+
+        Raises:
+            NotImplementedError: Always, until implemented.
+        """
+
+        raise NotImplementedError()

--- a/tests/unit/test_export_service.py
+++ b/tests/unit/test_export_service.py
@@ -1,0 +1,27 @@
+"""Unit tests for ExportService."""
+
+import pytest
+from unittest.mock import MagicMock
+
+from app.core.services.export import ExportService
+
+
+def test_export_products_to_sheets_not_implemented() -> None:
+    """Ensure exporting products to sheets is not implemented."""
+    service = ExportService(MagicMock(), MagicMock())
+    with pytest.raises(NotImplementedError):
+        service.export_products_to_sheets([])
+
+
+def test_export_inventory_to_sheets_not_implemented() -> None:
+    """Ensure exporting inventory to sheets is not implemented."""
+    service = ExportService(MagicMock(), MagicMock())
+    with pytest.raises(NotImplementedError):
+        service.export_inventory_to_sheets([])
+
+
+def test_export_products_to_drive_not_implemented() -> None:
+    """Ensure exporting products to drive is not implemented."""
+    service = ExportService(MagicMock(), MagicMock())
+    with pytest.raises(NotImplementedError):
+        service.export_products_to_drive([])

--- a/tests/unit/test_spreadsheet_builder.py
+++ b/tests/unit/test_spreadsheet_builder.py
@@ -1,0 +1,13 @@
+"""Unit tests for SpreadsheetBuilder."""
+
+from pathlib import Path
+import pytest
+
+from app.core.services.spreadsheet import SpreadsheetBuilder
+
+
+def test_get_sheet_data_not_implemented(tmp_path: Path) -> None:
+    """Ensure get_sheet_data is not implemented."""
+    builder = SpreadsheetBuilder(tmp_path / "template.xlsx")
+    with pytest.raises(NotImplementedError):
+        builder.get_sheet_data()


### PR DESCRIPTION
## Summary
- raise `NotImplementedError` for the unfinished spreadsheet builder logic
- raise `NotImplementedError` for each export function
- add unit tests covering the `NotImplementedError` behaviour

## Testing
- `pre-commit run --files app/core/services/spreadsheet.py app/core/services/export.py tests/unit/test_export_service.py tests/unit/test_spreadsheet_builder.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684772e23890832c8bc660601dd0dfa5