### PR TITLE
Remove dead user stub

### DIFF
--- a/app/core/services/auth.py
+++ b/app/core/services/auth.py
@@ -1,5 +1,6 @@
 from typing import Optional, Any
-from app.models import User, Session
+from app.core.models.user import User
+from app.core.auth.models import Session
 from app.extensions import db
 
 class AuthService:

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,5 +1,0 @@
-# Stub for app.models.user to satisfy mypy and test imports 
-
-# Stub for User model to satisfy import errors in tests
-class User:
-    pass 

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import patch, MagicMock
 from app.core import oauth
-from app.models.user import User
+from app.core.models.user import User
 from app import db
 from app.core.auth.models import Session
 from app.core.auth.service import AuthService

--- a/tests/integration/test_drive.py
+++ b/tests/integration/test_drive.py
@@ -2,7 +2,7 @@ import pytest
 from unittest.mock import patch, MagicMock
 from app.core.services.drive import DriveService
 from app.core.services.sheets import SheetsService
-from app.models.user import User
+from app.core.models.user import User
 from app import db
 
 @pytest.fixture

--- a/tests/integration/test_oauth.py
+++ b/tests/integration/test_oauth.py
@@ -2,7 +2,7 @@
 
 import pytest
 from unittest.mock import patch, MagicMock
-from app.models.user import User
+from app.core.models.user import User
 from flask import url_for
 
 def test_google_oauth_callback(client, db_session) -> None:

--- a/tests/integration/test_workspace.py
+++ b/tests/integration/test_workspace.py
@@ -1,7 +1,7 @@
 """Integration tests for workspace functionality."""
 
 import pytest
-from app.models.user import User
+from app.core.models.user import User
 from app.core.models.organisation import Organisation
 
 def test_workspace_creation(client, db_session, mock_drive_service) -> None:

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -2,7 +2,7 @@
 
 import pytest
 from datetime import datetime
-from app.models.user import User
+from app.core.models.user import User
 from app.core.models.organisation import Organisation
 from app.channels.woot.models import WootPorf, WootPorfLine, WootPorfStatus
 


### PR DESCRIPTION
## Summary
- drop obsolete `app.models.user`
- update all imports to use `app.core.models.user`
- reference session model from `app.core.auth.models`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `mypy app` *(fails: found 247 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684772d9a748832c99c88f6c8d6970d1