### PR TITLE
Refine channel sync and models

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -17,9 +17,11 @@ from .api import auth_bp, health_bp, organisation_bp
 from .config import CONFIG_MAP
 from .core.auth.oauth import init_oauth
 from .extensions import cors, db, init_celery, migrate
-from channels.woot.routes import bp as woot_bp
 from app.startup import preload_adapters
+
 preload_adapters()
+
+from app.channels.woot.routes import bp as woot_bp
 
 __all__ = ["create_app"]
 

--- a/app/channels/__init__.py
+++ b/app/channels/__init__.py
@@ -18,6 +18,7 @@ __all__ = [
 # ───────────────────────────── supported channels ───────────────────────────
 from enum import Enum, unique
 
+
 @unique
 class Channel(str, Enum):
     WOOT = "woot"
@@ -28,10 +29,12 @@ class Channel(str, Enum):
     def __str__(self) -> str:  # pragma: no cover
         return self.value
 
+
 # Single source of truth for validation elsewhere
 ALLOWED_CHANNELS: Final[set[str]] = {c.value for c in Channel}
 
 # ───────────────────────────── adapter contract ─────────────────────────────
+
 
 class ChannelAdapter(abc.ABC):
     """Every concrete adapter must implement this interface."""
@@ -39,6 +42,7 @@ class ChannelAdapter(abc.ABC):
     @abc.abstractmethod
     def fetch_orders(self) -> Iterable[OrderPayload]:  # pragma: no cover
         """Yield raw order payloads from the remote channel."""
+
 
 # ───────────────────────────── in‑memory registry ───────────────────────────
 
@@ -62,6 +66,7 @@ def register(name: str):
 
 # ───────────────────────────── import helpers ───────────────────────────────
 
+
 def import_channel(name: str) -> None:
     """Import ``app.channels.<name>`` so its decorators run.
 
@@ -72,6 +77,7 @@ def import_channel(name: str) -> None:
 
 # Optional lazy‑import fallback (for zero‑downtime adapter rollout).
 # Comment‑out this helper if you prefer to restart workers on every deploy.
+
 
 def _lazy_import_if_needed(name: str) -> None:
     if name in _REGISTRY:
@@ -84,6 +90,7 @@ def _lazy_import_if_needed(name: str) -> None:
 
 
 # ───────────────────────────── public accessor ──────────────────────────────
+
 
 def get_adapter(name: str) -> ChannelAdapter:
     """Return a *new* adapter instance for ``name``.

--- a/app/channels/__init__.py
+++ b/app/channels/__init__.py
@@ -4,8 +4,6 @@ import abc
 import importlib
 from typing import Iterable, Final
 
-from app.core.logic.orders import OrderPayload
-
 __all__ = [
     "ChannelAdapter",
     "Channel",
@@ -40,7 +38,7 @@ class ChannelAdapter(abc.ABC):
     """Every concrete adapter must implement this interface."""
 
     @abc.abstractmethod
-    def fetch_orders(self) -> Iterable[OrderPayload]:  # pragma: no cover
+    def fetch_orders(self) -> Iterable["OrderPayload"]:  # pragma: no cover
         """Yield raw order payloads from the remote channel."""
 
 

--- a/app/core/models/__init__.py
+++ b/app/core/models/__init__.py
@@ -6,7 +6,8 @@ from .base import BaseModel
 from .organisation import Organisation
 from .user import User
 from .product import MasterProduct, InventoryRecord
-from .order import OrderRecord, OrderLine, OrderStatus, Channel
+from .order import OrderRecord, OrderLine, OrderStatus
+from app.channels import Channel
 
 __all__ = [
     "BaseModel",

--- a/app/core/models/order.py
+++ b/app/core/models/order.py
@@ -12,13 +12,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from app.extensions import db
 from .base import BaseModel
 from .product import MasterProduct
-
-
-@unique
-class Channel(str, Enum):
-    WOOT = "woot"
-    AMAZON = "amazon"
-    EBAY = "ebay"
+from app.channels import Channel
 
 
 @unique

--- a/app/core/models/order.py
+++ b/app/core/models/order.py
@@ -1,4 +1,5 @@
 """Channel-independent order tables."""
+
 from __future__ import annotations
 
 from datetime import datetime, timezone
@@ -18,6 +19,7 @@ class Channel(str, Enum):
     WOOT = "woot"
     AMAZON = "amazon"
     EBAY = "ebay"
+
 
 @unique
 class OrderStatus(str, Enum):

--- a/app/core/models/organisation.py
+++ b/app/core/models/organisation.py
@@ -1,6 +1,8 @@
 # app/core/models/organisation.py
 from __future__ import annotations
 
+from sqlalchemy import CheckConstraint
+
 from app.extensions import db
 
 from .base import BaseModel
@@ -12,6 +14,13 @@ class Organisation(BaseModel):
     name = db.Column(db.String(255), unique=True, nullable=False)
     drive_folder_id = db.Column(db.String(256), unique=True, nullable=False)
 
+    __table_args__ = (
+        CheckConstraint(
+            "length(drive_folder_id) >= 25",
+            name="ck_drive_folder_id_format",
+        ),
+    )
+
     users = db.relationship(
         "User",
         back_populates="organisation",
@@ -21,3 +30,6 @@ class Organisation(BaseModel):
 
     def __repr__(self) -> str:  # pragma: no cover
         return f"<Organisation {self.name}>"
+
+
+__all__ = ["Organisation"]

--- a/app/core/models/user.py
+++ b/app/core/models/user.py
@@ -19,7 +19,10 @@ class User(BaseModel):
     last_name: Mapped[str | None] = mapped_column(db.String(120))
 
     allowed_channels: Mapped[list[str]] = mapped_column(
-        db.JSON, nullable=False, default=list, server_default="[]"
+        db.JSON,
+        nullable=False,
+        default=list,
+        server_default=sa_text("'[]'::jsonb"),
     )
 
     organisation_id: Mapped[int] = mapped_column(
@@ -30,10 +33,15 @@ class User(BaseModel):
     organisation: Mapped["Organisation"] = relationship(back_populates="users")
 
     __table_args__ = (
+        CheckConstraint(
+            "jsonb_typeof(allowed_channels) = 'array'",
+            name="ck_users_allowed_channels_array",
+        ),
         db.Index(
             "ix_users_allowed_channels_gin",
             "allowed_channels",
             postgresql_using="gin",
+            postgresql_ops={"allowed_channels": "jsonb_path_ops"},
         ),
     )
 

--- a/app/startup.py
+++ b/app/startup.py
@@ -1,10 +1,15 @@
+import logging
 import os
-from app.channels import import_channel, ALLOWED_CHANNELS
+
+from app.channels import ALLOWED_CHANNELS, import_channel
+
+log = logging.getLogger(__name__)
 
 def preload_adapters() -> None:
     names = os.getenv("SYNC_CHANNELS", ",".join(ALLOWED_CHANNELS)).split(",")
     for name in filter(None, names):
         try:
             import_channel(name)
-        except ModuleNotFoundError:  # channel package not deployed
+        except ModuleNotFoundError:
+            log.warning("SYNC_CHANNELS lists '%s' but package not deployed", name)
             continue

--- a/app/startup.py
+++ b/app/startup.py
@@ -4,4 +4,7 @@ from app.channels import import_channel, ALLOWED_CHANNELS
 def preload_adapters() -> None:
     names = os.getenv("SYNC_CHANNELS", ",".join(ALLOWED_CHANNELS)).split(",")
     for name in filter(None, names):
-        import_channel(name)
+        try:
+            import_channel(name)
+        except ModuleNotFoundError:  # channel package not deployed
+            continue

--- a/app/tasks/sync.py
+++ b/app/tasks/sync.py
@@ -1,21 +1,25 @@
 from __future__ import annotations
 
+import logging
 import os
 
 from celery import Task
 from sqlalchemy.exc import SQLAlchemyError
 
-from app.channels import import_channel, get_adapter, ALLOWED_CHANNELS
+from app.channels import ALLOWED_CHANNELS, get_adapter, import_channel
 from app.core.logic.orders import OrderSyncService
 from app.core.models.user import User
 from app.extensions import celery_app, db
+
+log = logging.getLogger(__name__)
 
 for _name in os.getenv("SYNC_CHANNELS", ",".join(ALLOWED_CHANNELS)).split(","):
     if not _name:
         continue
     try:
         import_channel(_name)
-    except ModuleNotFoundError:  # channel package not yet deployed
+    except ModuleNotFoundError:
+        log.warning("SYNC_CHANNELS lists '%s' but package not deployed", _name)
         continue
 
 
@@ -32,7 +36,7 @@ def _sync_user(user: User) -> int:
             continue
 
         for payload in adapter.fetch_orders():
-            logic.upsert(payload)
+            logic.upsert(payload, user=user)
             count += 1
 
     return count

--- a/migrations/versions/0002_add_user_allowed_channels.py
+++ b/migrations/versions/0002_add_user_allowed_channels.py
@@ -1,0 +1,34 @@
+"""Add User.allowed_channels column + index."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0002_add_user_allowed_channels"
+down_revision = "0001_initial"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column(
+            "allowed_channels",
+            sa.JSON(),
+            nullable=False,
+            server_default="[]",
+        ),
+    )
+    op.execute(
+        """
+        CREATE INDEX ix_users_allowed_channels_gin
+               ON users USING gin (allowed_channels jsonb_path_ops);
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_users_allowed_channels_gin", table_name="users")
+    op.drop_column("users", "allowed_channels")

--- a/migrations/versions/0002_add_user_allowed_channels.py
+++ b/migrations/versions/0002_add_user_allowed_channels.py
@@ -18,14 +18,20 @@ def upgrade() -> None:
             "allowed_channels",
             sa.JSON(),
             nullable=False,
-            server_default="[]",
+            server_default=sa.text("'[]'::jsonb"),
         ),
     )
-    op.execute(
-        """
-        CREATE INDEX ix_users_allowed_channels_gin
-               ON users USING gin (allowed_channels jsonb_path_ops);
-        """
+    op.create_index(
+        "ix_users_allowed_channels_gin",
+        "users",
+        ["allowed_channels"],
+        postgresql_using="gin",
+        postgresql_ops={"allowed_channels": "jsonb_path_ops"},
+    )
+    op.create_check_constraint(
+        "ck_users_allowed_channels_array",
+        "users",
+        "jsonb_typeof(allowed_channels) = 'array'",
     )
 
 

--- a/tests/integration/test_sync_task.py
+++ b/tests/integration/test_sync_task.py
@@ -1,0 +1,43 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from app.channels import ChannelAdapter, Channel
+from app.extensions import db
+from app.tasks.sync import _sync_user
+from app.core.models import Organisation, User, MasterProduct, OrderRecord, OrderStatus
+
+
+class FakeAdapter(ChannelAdapter):
+    def fetch_orders(self):
+        from app.core.logic.orders import OrderLinePayload, OrderPayload
+
+        yield OrderPayload(
+            ext_id="X1",
+            channel=Channel.WOOT,
+            placed_at=datetime.now(timezone.utc),
+            status=OrderStatus.NEW,
+            currency="USD",
+            total="5.00",
+            lines=[OrderLinePayload(sku="SKU1", quantity=1, unit_price="5.00")],
+        )
+
+
+@pytest.mark.usefixtures("app")
+def test_sync_task_inserts_orders(app, monkeypatch):
+    monkeypatch.setattr("app.tasks.sync.get_adapter", lambda name: FakeAdapter())
+
+    with app.app_context():
+        org = Organisation(name="Org", drive_folder_id="F" * 25 + "2")
+        db.session.add(org)
+        prod = MasterProduct(sku="SKU1", title="Item")
+        db.session.add(prod)
+        user = User(email="t@example.com", organisation=org, allowed_channels=["woot"])
+        db.session.add(user)
+        db.session.commit()
+
+        count = _sync_user(user)
+        db.session.commit()
+
+        assert count == 1
+        assert db.session.query(OrderRecord).count() == 1

--- a/tests/unit/test_adapter_registry.py
+++ b/tests/unit/test_adapter_registry.py
@@ -1,0 +1,7 @@
+from app.channels import import_channel, get_adapter
+
+
+def test_get_adapter_returns_instance():
+    import_channel("woot")
+    adapter = get_adapter("woot")
+    assert hasattr(adapter, "fetch_orders")

--- a/tests/unit/test_user_validation.py
+++ b/tests/unit/test_user_validation.py
@@ -1,0 +1,19 @@
+import pytest
+
+from app.core.models import User, Organisation
+from app.extensions import db
+
+
+def test_bad_channel_validation(app):
+    with app.app_context():
+        org = Organisation(name="Acme", drive_folder_id="F" * 25 + "1")
+        db.session.add(org)
+        db.session.commit()
+
+        user = User(email="a@example.com", organisation=org, allowed_channels=["woot"])
+        db.session.add(user)
+        db.session.commit()
+
+        with pytest.raises(ValueError):
+            user.allowed_channels = user.allowed_channels + ["bogus"]
+            db.session.flush()


### PR DESCRIPTION
## Summary
- add `as_dict` helper in `BaseModel`
- enforce channel validation on `User.allowed_channels`
- default adapter preload uses enum list and ignores missing modules
- sync task uses new preload logic and simplified upsert
- add Alembic revision for `allowed_channels`
- add tests for adapter registry, user validation and sync task

## Testing
- `pytest -q`
- `mypy app` *(fails: 53 errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_685b2735fe00832c8ced415cf7176982